### PR TITLE
docs: hide instructions from PR messages #8996

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,13 @@
 ## Proposed changes
 
-Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
+<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
 
-If this relates to a card, please include a link to the card here. Additionally, please terminate the PR title with `#` and the card number, such as `Fix doomsday bug #1234`
+If this relates to a card, please include a link to the card here. Additionally, please terminate the PR title with `#` and the card number, such as `Fix doomsday bug #1234` -->
 
 ## Types of changes
 
-What types of changes does your code introduce?
-_Put an `x` in the boxes that apply_
+<!-- What types of changes does your code introduce?
+_Put an `x` in the boxes that apply_ -->
 
 - [ ] feat: non-breaking change which adds new functionality
 - [ ] fix: non-breaking change which fixes a bug or an issue
@@ -21,12 +21,12 @@ _Put an `x` in the boxes that apply_
 - [ ] ci: changes to continuous integration or continuous delivery scripts or configuration files
 - [ ] chore: general tasks or anything that doesn't fit the other commit types
 
-Please indicate if your PR introduces a breaking change
+<!-- Please indicate if your PR introduces a breaking change -->
 - [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected
 
 ## Checklist
 
-_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
+<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->
 
 - [ ] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
 - [ ] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
@@ -35,4 +35,4 @@ _Put an `x` in the boxes that apply. You can also fill these out after creating 
 
 ## Further comments
 
-If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
+<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


### PR DESCRIPTION
## Proposed changes

As outlined in [Task #8996: Omit section descriptions/instructions from PR messages](https://team.linkorb.com/cards/8996), this PR converts section descriptions/instructions into HTML comments.

This change makes it so that such instructions are hidden in PR messages that are visible to reviewers. However, the instructions are visible when a contributor is editing the PR message.

## Types of changes

- [ ] feat: non-breaking change which adds new functionality
- [ ] fix: non-breaking change which fixes a bug or an issue
- [ ] chore(deps): changes to dependencies
- [ ] test: adds or modifies a test
- [x] docs: creates or updates documentation
- [ ] style: changes that do not affect the meaning or function of code (e.g. formatting, whitespace, missing semi-colons etc.)
- [ ] perf: code change that improves performance
- [ ] revert: reverts a commit
- [ ] refactor: code change that neither fix a bug nor add a new feature
- [ ] ci: changes to continuous integration or continuous delivery scripts or configuration files
- [ ] chore: general tasks or anything that doesn't fit the other commit types

Please indicate if your PR introduces a breaking change
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected

## Checklist

- [ ] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [ ] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)

## Further comments
